### PR TITLE
Provide TourStepTemplateService as singleton in forRoot

### DIFF
--- a/src/lib/plugin/ng-bootstrap/ng-bootstrap.module.ts
+++ b/src/lib/plugin/ng-bootstrap/ng-bootstrap.module.ts
@@ -12,13 +12,13 @@ export { TourAnchorNgBootstrapDirective };
   declarations: [TourAnchorNgBootstrapDirective, TourStepTemplateComponent],
   exports: [TourAnchorNgBootstrapDirective, TourStepTemplateComponent],
   imports: [CommonModule, NgbPopoverModule.forRoot()],
-  providers: [TourStepTemplateService],
 })
 export class TourNgBootstrapModule {
   public static forRoot(): ModuleWithProviders {
     return {
       ngModule: TourNgBootstrapModule,
       providers: [
+        TourStepTemplateService,
         TourModule.forRoot().providers,
       ],
     };


### PR DESCRIPTION
When using TourNgBootstrapModule in async modules, there are multiple TourStepTemplateService objects, which causes incorrect calculations for the template.
