### PR TITLE
Fix problem with polyfill scrollIntoViewIfNeeded import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ng2-tour",
+  "name": "ng2-tour-fix",
   "version": "0.1.5",
   "description": "Product tour library built in Angular (2+)",
   "main": "index.js",
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/isaacplmann/ng2-tour.git"
+    "url": "git+https://github.com/ellesse/ng2-tour.git"
   },
   "author": {
     "name": "isaacplmann",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ng2-tour-fix",
+  "name": "ng2-tour",
   "version": "0.1.5",
   "description": "Product tour library built in Angular (2+)",
   "main": "index.js",
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ellesse/ng2-tour.git"
+    "url": "git+https://github.com/isaacplmann/ng2-tour.git"
   },
   "author": {
     "name": "isaacplmann",

--- a/src/lib/plugin/ng-bootstrap/tour-anchor.directive.ts
+++ b/src/lib/plugin/ng-bootstrap/tour-anchor.directive.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover/popover';
 import { NgbPopoverConfig } from '@ng-bootstrap/ng-bootstrap';
-const scrollIntoViewIfNeeded = require('scroll-into-view-if-needed');
+const scrollIntoViewIfNeeded = require('scroll-into-view-if-needed').default;
 
 @Directive({
   selector: '[tourAnchor]',


### PR DESCRIPTION
I was obtaining a "TypeError: scrollIntoViewIfNeeded is not a function" error due to a possible issue in the way the   'scroll-into-view-if-needed' is required/exported (see https://github.com/Microsoft/TypeScript/issues/2719). 

Substituting 
`const scrollIntoViewIfNeeded = require('scroll-into-view-if-needed')`
with 
`const scrollIntoViewIfNeeded = require('scroll-into-view-if-needed').default;`

fixed the problem. 