### PR TITLE
Update  tour-anchor.directive.ts

### DIFF
--- a/src/lib/plugin/ng-bootstrap/tour-anchor.directive.ts
+++ b/src/lib/plugin/ng-bootstrap/tour-anchor.directive.ts
@@ -45,6 +45,7 @@ export class TourAnchorNgBootstrapDirective extends NgbPopover implements OnInit
     console.log(step);
     this.ngbPopover = this.tourStepTemplate.template;
     this.popoverTitle = step.title;
+    this.container =  'body';
     switch (step.placement) {
       case 'above':
         this.placement = 'top';


### PR DESCRIPTION
When a parent element to an anchor has the overflow 'hidden' or 'auto' property, the popover is obstructed.
Added ' this.container =  'body' to prevent.